### PR TITLE
🦨 [gitignore] ignore tfstate and other temporary terraform/openbao files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,11 @@ inc/
 /MANIFEST.bak
 /pm_to_blib
 /*.zip
+
+# Terraform files
+*.tfstate
+*.tfstate.*
+.terraform/
+.terraform.lock.hcl
+terraform.tfvars
+*.tfplan


### PR DESCRIPTION
## Done:

- 🦨 [gitignore] ignore tfstate and other temporary terraform/openbao files


(Automated in `justfile`.)
