### PR TITLE
🟢 [logs-cdn] rename an output to work better for remote state

### DIFF
--- a/l4_data/logs-cdn/README.md
+++ b/l4_data/logs-cdn/README.md
@@ -45,7 +45,7 @@ No modules.
 | Name | Description |
 |------|-------------|
 | environment | Environment name |
-| logs\_cdn\_bucket\_name | Name of the CDN logs bucket |
+| logs\_cdn\_bucket\_id | ID/name of the CDN logs bucket |
 | logs\_cdn\_bucket\_urn | URN of the CDN logs bucket |
 | region | DigitalOcean region |
 <!-- END_TF_DOCS -->

--- a/l4_data/logs-cdn/outputs.tf
+++ b/l4_data/logs-cdn/outputs.tf
@@ -8,12 +8,12 @@ output "region" {
   value       = var.region
 }
 
-output "logs_cdn_bucket_name" {
-  description = "Name of the CDN logs bucket"
-  value       = digitalocean_spaces_bucket.logs_cdn_bucket.name
-}
-
 output "logs_cdn_bucket_urn" {
   description = "URN of the CDN logs bucket"
   value       = digitalocean_spaces_bucket.logs_cdn_bucket.urn
+}
+
+output "logs_cdn_bucket_id" {
+  description = "ID/name of the CDN logs bucket"
+  value       = digitalocean_spaces_bucket.logs_cdn_bucket.id
 }


### PR DESCRIPTION
## Done:

- 🟢 [logs-cdn] rename an output to work better for remote state


(Automated in `justfile`.)
