### PR TITLE
🎞  [readme add architecture diagram to CDN doc

### DIFF
--- a/l6_ingress/cdn-fini-domain-trust/README.md
+++ b/l6_ingress/cdn-fini-domain-trust/README.md
@@ -5,7 +5,7 @@ serving a set of sites.
 
 ## Architecture diagram
 
-![architecture diagram](../../architecture/diagrams/fini_static_web_serving.png)
+![FINI Static Web Serving architecture diagram](../../architecture/diagrams/fini_static_web_serving.png)
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements


### PR DESCRIPTION
## Done

- 🎞  [readme add architecture diagram to CDN doc


## Meta

(Automated in `.just/gh-process.just`.)
