### PR TITLE
🥽 [claude] allow terraform stuff, dig, and docs.dnscontrol.org site

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -7,13 +7,20 @@
       "WebFetch(domain:raw.githubusercontent.com)",
       "WebFetch(domain:en.wikipedia.org)",
       "WebFetch(domain:docs.digitalocean.com)",
+      "WebFetch(domain:registry.terraform.io)",
+      "WebFetch(domain:docs.dnscontrol.org)",
       "WebSearch",
       "Bash(markdownlint-cli2:*)",
       "Bash(gh pr view:*)",
       "Bash(gh pr diff:*)",
       "Bash(git log:*)",
       "Bash(identify:*)",
-      "Bash(just shellcheck:*)"
+      "Bash(just shellcheck:*)",
+      "Bash(just tf-docs:*)",
+      "Bash(just tf-state:*)",
+      "Bash(just tf-output:*)",
+      "Bash(tofu state list:*)",
+      "Bash(dig:*)"
     ],
     "deny": [],
     "ask": []


### PR DESCRIPTION
## Done

- 🥽 [claude] allow terraform stuff, dig, and docs.dnscontrol.org site


## Meta

(Automated in `.just/gh-process.just`.)
