### PR TITLE
🤝 [gha] only trigger GHA linters for .github/*

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -23,8 +23,8 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Check workflow files
-        uses: docker://rhysd/actionlint:latest
+        uses: docker://rhysd/actionlint:sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667 # 1.7.12
         with:
           args: -color

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -23,8 +23,12 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@de0fac2e4500dabe0009e6eb47ee0d3520686341fec936f3b79331f9315667 # v6.0.2
       - name: Check workflow files
-        uses: docker://rhysd/actionlint:sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667 # 1.7.12
+        uses: docker://rhysd/actionlint@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667 # 1.7.12
         with:
           args: -color

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -4,8 +4,12 @@ on:
   # Triggers the workflow on push or pull request events but only for the "main" branch
   push:
     branches: [ "main" ]
+    paths:
+      - ".github/**"
   pull_request:
     branches: [ "main" ]
+    paths:
+      - ".github/**"
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -27,7 +27,7 @@ jobs:
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
           egress-policy: audit
-      - uses: actions/checkout@de0fac2e4500dabe0009e6eb47ee0d3520686341fec936f3b79331f9315667 # v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Check workflow files
         uses: docker://rhysd/actionlint@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667 # 1.7.12
         with:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -3,8 +3,12 @@ name: GHA security analysis with zizmor
 on:
   push:
     branches: ["main"]
+    paths:
+      - ".github/**"
   pull_request:
     branches: ["main"]
+    paths:
+      - ".github/**"
   workflow_dispatch:
 
 # global permissions


### PR DESCRIPTION
<!-- PR_BODY_DONE_START -->
## Done

- 🤝 [gha] only trigger GHA linters for .github/*
- pin actionlint by gitsha
- proper pin for actionlint and add step-security/harden-runner
- correct gitsha for checkout in actionlint

<!-- PR_BODY_DONE_END -->

## Meta

(Automated in `.just/gh-process.just`.)
